### PR TITLE
Feat/1.1.7.1 MC 1.21.11 micro update

### DIFF
--- a/versions/1.21.11/config/iris.properties
+++ b/versions/1.21.11/config/iris.properties
@@ -5,4 +5,4 @@ disableUpdateMessage=true
 enableDebugOptions=false
 enableShaders=True
 maxShadowRenderDistance=12
-shaderPack=Mellow Shader v2.2.1.zip
+shaderPack=Mellow Shader v3.0.1.zip

--- a/versions/1.21.11/index.toml
+++ b/versions/1.21.11/index.toml
@@ -49,42 +49,42 @@ metafile = true
 
 [[files]]
 file = "mods/entityculling.pw.toml"
-hash = "6adf5f512651c200a320219c32a3a51c8b95e219206f64b99cb93940d51b2cfa"
+hash = "c23a1be7641341478b09c5c4f835b5e024a246f9e8521e92905bcab0d0e8cce0"
 metafile = true
 
 [[files]]
 file = "mods/entitytexturefeatures.pw.toml"
-hash = "09d9bcf41357ee2baf28a26418bc1ed5d68ad7044252e976081295bde8dddb2e"
+hash = "6085d2f0a5deabc026667492ac344d9b9007c80ccadb3f916fe9b0ec3037f022"
 metafile = true
 
 [[files]]
 file = "mods/fabric-api.pw.toml"
-hash = "7adc0d54f139075d8f90dae18ca476753cc3145a70e09c9327736024adfe9b30"
+hash = "45abf05e1cc90006aeb65e4e1bbe97da5a1984f547ea8028a077dae68af0ac11"
 metafile = true
 
 [[files]]
 file = "mods/fabric-language-kotlin.pw.toml"
-hash = "61afd7af5c645ffd966b2bd86be944eacd1e48a8044e8f67082225d4d9989f0c"
+hash = "408151861cc1b1a4c4e9c8a3550662a2fc36d0ea96ee07b7e96c5d2a6afacf6f"
 metafile = true
 
 [[files]]
 file = "mods/ferrite-core.pw.toml"
-hash = "76a12a836d4c7f0f943a1e391dd2d7b5c4673caa497fff16593d49449376b117"
+hash = "816b735b2ad505476201800a99f527e61b392b712b9d20ca9edcce05f412fe87"
 metafile = true
 
 [[files]]
 file = "mods/immediatelyfast.pw.toml"
-hash = "402069ebe33a1f19e6e5c0c0235267b832ba44617f15ddbdc677faf2a2607e38"
+hash = "9e7bacd24307639764f3b74ae35a562b6becf2701637b816de0eaae15ab714c0"
 metafile = true
 
 [[files]]
 file = "mods/iris.pw.toml"
-hash = "b7d33095f206cb34dc8cd3d5410a00597439a2fc793f4c158c7a2ecfc7e85e82"
+hash = "276947b1f9933ca2220a00736aba177e4034ca9a45cad9f258abf762fdb3bb0b"
 metafile = true
 
 [[files]]
 file = "mods/lithium.pw.toml"
-hash = "88a36b21d538d44aca7dd0a7e5ad8c09b1b263be3f4381e3bb22bc9f94ee7290"
+hash = "9a74f9345a91af6a0e2c1975e1dd1d26cfcae6fb072a3a0d68fd9de110ab6327"
 metafile = true
 
 [[files]]
@@ -99,17 +99,17 @@ metafile = true
 
 [[files]]
 file = "mods/modmenu.pw.toml"
-hash = "c66e4b3576440113259b5bae8d0660b8e0023ce852156f27383f8651ecc4bfe3"
+hash = "51ff93e279e03cb3cd77a5be0df777cdcd975d35b5149180d9dc724e47168c76"
 metafile = true
 
 [[files]]
 file = "mods/moreculling.pw.toml"
-hash = "05e66fdfaf3f922718f38a18090c498d612160d342a7e3846fb7f666cf8bac3d"
+hash = "0544fefc6f04f2b408b2c6b4dd3e4bf7d0a4048f1fad6ddf63357549d7446165"
 metafile = true
 
 [[files]]
 file = "mods/reeses-sodium-options.pw.toml"
-hash = "383d8df46529ce54b4b0574be2fd9eba4f45d8c85aa668604e152fca3e439f5a"
+hash = "565c943b5006c36137a2fe55e4b8433e134c3d1011a37c5f5124cee67b671cb8"
 metafile = true
 
 [[files]]
@@ -119,7 +119,7 @@ metafile = true
 
 [[files]]
 file = "mods/shulkerboxtooltip.pw.toml"
-hash = "74be0b1016b6ed8a42c1b819af90393c2c74ac7e43248508d03ab7d7b6d55a07"
+hash = "842c53716951d19d2e791d45f3d6f1d3c6eab669db7bc3818c1a425282248aa1"
 metafile = true
 
 [[files]]
@@ -129,27 +129,27 @@ metafile = true
 
 [[files]]
 file = "mods/simple-voice-chat.pw.toml"
-hash = "0cbc900ae05bdd88801539eeee6b95dde99426f1d5c2c7c8c194e5f78bbd6e52"
+hash = "9ff1a261860fcb16a7c7f124d738abcdfc1297363412d237540685003ff04d6b"
 metafile = true
 
 [[files]]
 file = "mods/sodium-extra.pw.toml"
-hash = "80fe8de18aab2ba3399f61c6a74a4ad70e56bf5ed49f5fc0f051190d3ba59f2b"
+hash = "986e43ff06d2a79effec6e219aca063d7b53a98096c5f63983f23cf54c11c7e5"
 metafile = true
 
 [[files]]
 file = "mods/sodium.pw.toml"
-hash = "dd8c7eed10a3639d76595603142e1d18f6d26262747138c9442d70311006be5e"
+hash = "9d340481c374a20067d1748c1a4991626bce9d7812f0bdb96072cd7a15d35462"
 metafile = true
 
 [[files]]
 file = "mods/yacl.pw.toml"
-hash = "1dcded58f392b753b3acaaae02573c5d52e16672eab0e7cab66fc5f21eec6b5e"
+hash = "1eb651becf915f329a0a7000155846fe9b21c15740b7d82f8c3545b42b57f42f"
 metafile = true
 
 [[files]]
 file = "mods/zoomify.pw.toml"
-hash = "d74d244b3524bea2326becd2ceaa27b8e231156aba33448533cd29b12ed48318"
+hash = "3ff0c2f005f2523f157b776f0e870494a8e8ec0ff77cb7e965c88b4e2090efdb"
 metafile = true
 
 [[files]]
@@ -163,7 +163,7 @@ metafile = true
 
 [[files]]
 file = "resourcepacks/translations-for-sodium.pw.toml"
-hash = "c4ba6cd61ca21168bf3f8f95a9826d5a18733d060c9ed454be818bf68b587552"
+hash = "469932a499ec40d9b6f4fa00119d514ad77648d5a407efc96402a68e20b9c75a"
 metafile = true
 
 [[files]]
@@ -180,30 +180,35 @@ hash = "dcb1f267a0a228ed75b11f0911c558ce32205431161bec449c7e73ca1de2216b"
 
 [[files]]
 file = "shaderpacks/bsl-shaders.pw.toml"
-hash = "87225b53fc99a1bd3175357d9b7d359924877f30656550e563d16caa4a9373e1"
+hash = "015b33a9619d0a9ce18bc30b0a06dbb388b7d8ba0f24d63b4bc3db88bdb25101"
 metafile = true
 
 [[files]]
 file = "shaderpacks/complementary-reimagined.pw.toml"
-hash = "531a8d239c952428d9a633ff99cb03461656ada28decbe2e1ef19f60f7fd5726"
+hash = "b769a2f7ef2fa754224c5068491e79d02c0c85e0bc326fc05247f18315cc866b"
 metafile = true
 
 [[files]]
 file = "shaderpacks/complementary-unbound.pw.toml"
-hash = "134b3cee2ac2b5c5b9d02d8d70e8e4ba32c7c241f5bc51209521831a7c254e22"
+hash = "5caf93fa1624aeb26d11cdbadcb0c03b2a92815c798a930014774c7d525baf28"
 metafile = true
 
 [[files]]
 file = "shaderpacks/makeup-ultra-fast-shaders.pw.toml"
-hash = "05dd4aac0131eeef4c1ff5601c294e615cbc38890e50dda7ecbd18c14d2748eb"
+hash = "5497d3ab3f39171289a05ce996b3a757e960c2200a3d9435124762f056a74b4e"
 metafile = true
 
 [[files]]
 file = "shaderpacks/mellow.pw.toml"
-hash = "5ec54f83c22e4936ddffffa57fbf09c603effa0a5dbbcbd0f9e7d74f8e72f4b7"
+hash = "e2e989fc2093f98a987e588c62160f7500c0cadb5df9b48cfbf05d83e1f3c058"
 metafile = true
 
 [[files]]
 file = "shaderpacks/miniature-shader.pw.toml"
-hash = "3e1dabbdda0ccd24e816482cdecf0531ebf70ee775d98457d309cab831091a76"
+hash = "06d8b80e204e34536e4f9b3598934208bc08e5d76c656f0e2112821c0e040776"
+metafile = true
+
+[[files]]
+file = "shaderpacks/super-duper-vanilla.pw.toml"
+hash = "a8d4f22b92a8261aaa83177c718b05d5225d81c0cd2aab5ce69039f77cfb42c2"
 metafile = true

--- a/versions/1.21.11/mods/entityculling.pw.toml
+++ b/versions/1.21.11/mods/entityculling.pw.toml
@@ -1,13 +1,13 @@
 name = "Entity Culling"
-filename = "entityculling-fabric-1.9.4-mc1.21.11.jar"
+filename = "entityculling-fabric-1.9.5-mc1.21.11.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/NNAgCjsB/versions/P9ZiZM7Q/entityculling-fabric-1.9.4-mc1.21.11.jar"
+url = "https://cdn.modrinth.com/data/NNAgCjsB/versions/Dx3xsUER/entityculling-fabric-1.9.5-mc1.21.11.jar"
 hash-format = "sha512"
-hash = "a28bd3c0b34e49d3cf11bd6354f19b153de2607113d0efe8765a1bca1a8b318e4df9ffd4862b80210f7b17ff0bb8fff3e86efd19cea994b0899ea41e3b2dfc11"
+hash = "1222e523900fafa6690f992d889471dbe9819de33ac72b0c26f6b6563a181befe714d0d737c608ca94c566c8c015f1fe6cb1b5286d7043468c244d040a27036e"
 
 [update]
 [update.modrinth]
 mod-id = "NNAgCjsB"
-version = "P9ZiZM7Q"
+version = "Dx3xsUER"

--- a/versions/1.21.11/mods/entitytexturefeatures.pw.toml
+++ b/versions/1.21.11/mods/entitytexturefeatures.pw.toml
@@ -1,13 +1,13 @@
 name = "[ETF] Entity Texture Features"
-filename = "entity_texture_features_1.21.11-fabric-7.0.7.jar"
+filename = "entity_texture_features_1.21.11-fabric-7.0.8.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/BVzZfTc1/versions/918qa4eC/entity_texture_features_1.21.11-fabric-7.0.7.jar"
+url = "https://cdn.modrinth.com/data/BVzZfTc1/versions/q8oFU6IP/entity_texture_features_1.21.11-fabric-7.0.8.jar"
 hash-format = "sha512"
-hash = "1273c36883c13ef4f14b551b155ad6cbce37ab336283100ba43f50bee83c716eaa584ec472b62a8e3c6318989e63f616d6b9ad04fa6931f6e8fe383e4dee5e27"
+hash = "a41b2f59d2aae8022a8e107dfd776291d24ba2dcaf2e1b36eb706bb39a7b2f0ab829725d12339a116fdb1f14d643181aa0c9d9930fbc9c9fbd7d61153a52b1c4"
 
 [update]
 [update.modrinth]
 mod-id = "BVzZfTc1"
-version = "918qa4eC"
+version = "q8oFU6IP"

--- a/versions/1.21.11/mods/fabric-api.pw.toml
+++ b/versions/1.21.11/mods/fabric-api.pw.toml
@@ -1,13 +1,13 @@
 name = "Fabric API"
-filename = "fabric-api-0.140.2+1.21.11.jar"
+filename = "fabric-api-0.141.3+1.21.11.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/P7dR8mSH/versions/gB6TkYEJ/fabric-api-0.140.2%2B1.21.11.jar"
+url = "https://cdn.modrinth.com/data/P7dR8mSH/versions/i5tSkVBH/fabric-api-0.141.3%2B1.21.11.jar"
 hash-format = "sha512"
-hash = "af4465797d80401021a6aefc8c547200e7c0f8cae134299bf3fafbc310fa81f055246b0614fc0e037538f4a844e55aad30abfa3c67460422853dfc426f086d00"
+hash = "c20c017e23d6d2774690d0dd774cec84c16bfac5461da2d9345a1cd95eee495b1954333c421e3d1c66186284d24a433f6b0cced8021f62e0bfa617d2384d0471"
 
 [update]
 [update.modrinth]
 mod-id = "P7dR8mSH"
-version = "gB6TkYEJ"
+version = "i5tSkVBH"

--- a/versions/1.21.11/mods/fabric-language-kotlin.pw.toml
+++ b/versions/1.21.11/mods/fabric-language-kotlin.pw.toml
@@ -1,13 +1,13 @@
 name = "Fabric Language Kotlin"
-filename = "fabric-language-kotlin-1.13.8+kotlin.2.3.0.jar"
+filename = "fabric-language-kotlin-1.13.9+kotlin.2.3.10.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/Ha28R6CL/versions/N6D3uiZF/fabric-language-kotlin-1.13.8%2Bkotlin.2.3.0.jar"
+url = "https://cdn.modrinth.com/data/Ha28R6CL/versions/ViT4gucI/fabric-language-kotlin-1.13.9%2Bkotlin.2.3.10.jar"
 hash-format = "sha512"
-hash = "90bf59f810ea62363bdd7b2ce85a6268b7db67d6d4ce5ae6555204bc7eff0446a6e17d60ef51ad41bf85e92ca430043a8f7c21157cbaee9279733304605cc4d0"
+hash = "498672ee88cf703685026e74f82a85e30d980c62a1c8cc14744cb73add09a857db8d585b405e19f558ec490613642750eb00e09d8ef5a3c9578bc52b53568d51"
 
 [update]
 [update.modrinth]
 mod-id = "Ha28R6CL"
-version = "N6D3uiZF"
+version = "ViT4gucI"

--- a/versions/1.21.11/mods/ferrite-core.pw.toml
+++ b/versions/1.21.11/mods/ferrite-core.pw.toml
@@ -1,13 +1,13 @@
 name = "FerriteCore"
-filename = "ferritecore-8.0.3-fabric.jar"
+filename = "ferritecore-8.2.0-fabric.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/uXXizFIs/versions/eRLwt73x/ferritecore-8.0.3-fabric.jar"
+url = "https://cdn.modrinth.com/data/uXXizFIs/versions/Ii0gP3D8/ferritecore-8.2.0-fabric.jar"
 hash-format = "sha512"
-hash = "be600543e499b59286f9409f46497570adc51939ae63eaa12ac29e6778da27d8c7c6cd0b3340d8bcca1cc99ce61779b1a8f52b990f9e4e9a93aa9c6482905231"
+hash = "3210926a82eb32efd9bcebabe2f6c053daf5c4337eebc6d5bacba96d283510afbde646e7e195751de795ec70a2ea44fef77cb54bf22c8e57bb832d6217418869"
 
 [update]
 [update.modrinth]
 mod-id = "uXXizFIs"
-version = "eRLwt73x"
+version = "Ii0gP3D8"

--- a/versions/1.21.11/mods/immediatelyfast.pw.toml
+++ b/versions/1.21.11/mods/immediatelyfast.pw.toml
@@ -1,13 +1,13 @@
 name = "ImmediatelyFast"
-filename = "ImmediatelyFast-Fabric-1.14.1+1.21.11.jar"
+filename = "ImmediatelyFast-Fabric-1.14.2+1.21.11.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/5ZwdcRci/versions/XCnavm6o/ImmediatelyFast-Fabric-1.14.1%2B1.21.11.jar"
+url = "https://cdn.modrinth.com/data/5ZwdcRci/versions/QwkfUKSj/ImmediatelyFast-Fabric-1.14.2%2B1.21.11.jar"
 hash-format = "sha512"
-hash = "6534609849c4b33951d3b6ce0c83dd9272181f8d1d9d8cf39bbca8b5a2e3cbb498200d36844454bb3e52e4943fc9a556f52674b53be4f07fe897f0bf5689ea66"
+hash = "dedff930a4e317994579020eaeef9f56d81d5215d871372d206fc974842d87e80e4be15d8571a4eaa4320c2412701ea093ba4494a47e8988e3d448ec8adcba37"
 
 [update]
 [update.modrinth]
 mod-id = "5ZwdcRci"
-version = "XCnavm6o"
+version = "QwkfUKSj"

--- a/versions/1.21.11/mods/iris.pw.toml
+++ b/versions/1.21.11/mods/iris.pw.toml
@@ -1,13 +1,13 @@
 name = "Iris Shaders"
-filename = "iris-fabric-1.10.4+mc1.21.11.jar"
+filename = "iris-fabric-1.10.5+mc1.21.11.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/YL57xq9U/versions/Q4YiZeCX/iris-fabric-1.10.4%2Bmc1.21.11.jar"
+url = "https://cdn.modrinth.com/data/YL57xq9U/versions/ZQx4ktUs/iris-fabric-1.10.5%2Bmc1.21.11.jar"
 hash-format = "sha512"
-hash = "e555eb98aa0306d8a6337d4eb9402f7c994906c341bc5f1f0f9929a164bfd88266c714a4446635c961d17228691d0f7b15d8d74917ed5cec5f4fc6feb9d32005"
+hash = "e42a65e03c324c44847255e255dba4e75d65093bccd2b4e4804f297bf8505e218fbd5a600b8dda8fbe73229eb90ae710c7133e43aa2029b961a686600539ed79"
 
 [update]
 [update.modrinth]
 mod-id = "YL57xq9U"
-version = "Q4YiZeCX"
+version = "ZQx4ktUs"

--- a/versions/1.21.11/mods/lithium.pw.toml
+++ b/versions/1.21.11/mods/lithium.pw.toml
@@ -1,13 +1,13 @@
 name = "Lithium"
-filename = "lithium-fabric-0.21.1+mc1.21.11.jar"
+filename = "lithium-fabric-0.21.3+mc1.21.11.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/gvQqBUqZ/versions/4DdLmtyz/lithium-fabric-0.21.1%2Bmc1.21.11.jar"
+url = "https://cdn.modrinth.com/data/gvQqBUqZ/versions/qvNsoO3l/lithium-fabric-0.21.3%2Bmc1.21.11.jar"
 hash-format = "sha512"
-hash = "0857d30d063dc704a264b2fe774a7e641926193cfdcde72fe2cd603043d8548045b955e30c05b1b2b96ef7d1c0f85d55269da26f44a0644c984b45623e976794"
+hash = "2883739303f0bb602d3797cc601ed86ce6833e5ec313ddce675f3d6af3ee6a40b9b0a06dafe39d308d919669325e95c0aafd08d78c97acd976efde899c7810fd"
 
 [update]
 [update.modrinth]
 mod-id = "gvQqBUqZ"
-version = "4DdLmtyz"
+version = "qvNsoO3l"

--- a/versions/1.21.11/mods/modmenu.pw.toml
+++ b/versions/1.21.11/mods/modmenu.pw.toml
@@ -1,13 +1,13 @@
 name = "Mod Menu"
-filename = "modmenu-17.0.0-beta.1.jar"
+filename = "modmenu-17.0.0-beta.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/mOgUt4GM/versions/hGuj7hNc/modmenu-17.0.0-beta.1.jar"
+url = "https://cdn.modrinth.com/data/mOgUt4GM/versions/JWQVh32x/modmenu-17.0.0-beta.2.jar"
 hash-format = "sha512"
-hash = "bb0878d3ff2ddd9e4c6312d25eee5367b1ed114ea71baa07dbc30e13716f64d0bcebb1fccf37ca42ead0afb92044dccaef66b8c1c5d3946709e309d5d32f1984"
+hash = "27cc0fd2c9426e8eba70f96b9d31e6dd756819cc44338b8948167e93fb6e22416d10d2e8c63f7c689c2aca2c27bdb6864d974b92e3f79b3027d23eee1bfbdb2e"
 
 [update]
 [update.modrinth]
 mod-id = "mOgUt4GM"
-version = "hGuj7hNc"
+version = "JWQVh32x"

--- a/versions/1.21.11/mods/moreculling.pw.toml
+++ b/versions/1.21.11/mods/moreculling.pw.toml
@@ -1,13 +1,13 @@
 name = "More Culling"
-filename = "moreculling-fabric-1.21.11-1.6.0-beta.2.jar"
+filename = "moreculling-fabric-1.21.11-1.6.1.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/51shyZVL/versions/Ju23l9rz/moreculling-fabric-1.21.11-1.6.0-beta.2.jar"
+url = "https://cdn.modrinth.com/data/51shyZVL/versions/kWU8mVq5/moreculling-fabric-1.21.11-1.6.1.jar"
 hash-format = "sha512"
-hash = "5d54ceba9a839d615cfcd32e1d1e1f054299fbcf165dcaccfd5b8f175d45f569c7c28cd6a5a8830c3bc52527bf0d93aac0eb0d565e8e5e331a2677b964768f17"
+hash = "86b9ab2123c8419963a10d14177e6337b13623e077b3a8d240c9575fe583b1eb377ce8e128b5caf3ab6cd958f25d8f0163131aef7de59791cd6683eef0703663"
 
 [update]
 [update.modrinth]
 mod-id = "51shyZVL"
-version = "Ju23l9rz"
+version = "kWU8mVq5"

--- a/versions/1.21.11/mods/reeses-sodium-options.pw.toml
+++ b/versions/1.21.11/mods/reeses-sodium-options.pw.toml
@@ -1,13 +1,13 @@
 name = "Reese's Sodium Options"
-filename = "reeses-sodium-options-fabric-2.0.2+mc1.21.11.jar"
+filename = "reeses-sodium-options-fabric-2.0.3+mc1.21.11.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/Bh37bMuy/versions/gmIM6uan/reeses-sodium-options-fabric-2.0.2%2Bmc1.21.11.jar"
+url = "https://cdn.modrinth.com/data/Bh37bMuy/versions/yIgAFMna/reeses-sodium-options-fabric-2.0.3%2Bmc1.21.11.jar"
 hash-format = "sha512"
-hash = "48a6699a91230db9fb0f693e931d6006fb1d011f6d0f6d520da9307a9d451949c24d1836bd6026568666d2028e2bf814c6ff843d6a4c8b5570bf6bcd860dead4"
+hash = "13b54698be3cbecdcf544ff92186423652c6b1e91544864c979f51297a3159137f794db4e3ee21e0bae3abcf651bb4ecc0e2a5b4aa1eab1f1a81d6529fe82e59"
 
 [update]
 [update.modrinth]
 mod-id = "Bh37bMuy"
-version = "gmIM6uan"
+version = "yIgAFMna"

--- a/versions/1.21.11/mods/shulkerboxtooltip.pw.toml
+++ b/versions/1.21.11/mods/shulkerboxtooltip.pw.toml
@@ -1,13 +1,13 @@
 name = "Shulker Box Tooltip"
-filename = "shulkerboxtooltip-fabric-5.2.14+1.21.11.jar"
+filename = "shulkerboxtooltip-fabric-5.2.15+1.21.11.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/2M01OLQq/versions/8Z4OG11C/shulkerboxtooltip-fabric-5.2.14%2B1.21.11.jar"
+url = "https://cdn.modrinth.com/data/2M01OLQq/versions/2lPKqJBJ/shulkerboxtooltip-fabric-5.2.15%2B1.21.11.jar"
 hash-format = "sha512"
-hash = "55490c21c98a6c5bd704674a7435a7df2853e9e7ab8872b2a62264444110ad11eac23133e0c1e36ff484531bf849d5fa4a71eb0bf32a9b9c4f3afe33779d1c71"
+hash = "a8a969056af71e25e086c9566fdfc8b50780162e5b335fe41776fa4f0c0f2edbf0c95c42453dca0b0b72f9f71d9bfa433f756aa2272043e9dd17fe8fb6f488dd"
 
 [update]
 [update.modrinth]
 mod-id = "2M01OLQq"
-version = "8Z4OG11C"
+version = "2lPKqJBJ"

--- a/versions/1.21.11/mods/simple-voice-chat.pw.toml
+++ b/versions/1.21.11/mods/simple-voice-chat.pw.toml
@@ -1,13 +1,13 @@
 name = "Simple Voice Chat"
-filename = "voicechat-fabric-1.21.11-2.6.10.jar"
+filename = "voicechat-fabric-1.21.11-2.6.11.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/9eGKb6K1/versions/T42QJY4i/voicechat-fabric-1.21.11-2.6.10.jar"
+url = "https://cdn.modrinth.com/data/9eGKb6K1/versions/1OVXKX2W/voicechat-fabric-1.21.11-2.6.11.jar"
 hash-format = "sha512"
-hash = "5da377423b2e48cf6729eab3f67eb82b21d591dee8ff060b2f9295c2743994ca3b49abe77c4b8d2480286c7e6e71f2f19afaf45e13d3794685b726cf2431fc19"
+hash = "2ddab762110037616ef55403f97dfb4fa6df7c37bc12554a6f4d4bb40cebe102ff671c4876bb3cb0f98ad2542f414b079a6e48aa20656c9a13c4bfbdf908b534"
 
 [update]
 [update.modrinth]
 mod-id = "9eGKb6K1"
-version = "T42QJY4i"
+version = "1OVXKX2W"

--- a/versions/1.21.11/mods/sodium-extra.pw.toml
+++ b/versions/1.21.11/mods/sodium-extra.pw.toml
@@ -1,13 +1,13 @@
 name = "Sodium Extra"
-filename = "sodium-extra-fabric-0.8.1+mc1.21.11.jar"
+filename = "sodium-extra-fabric-0.8.3+mc1.21.11.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/PtjYWJkn/versions/USJvTNro/sodium-extra-fabric-0.8.1%2Bmc1.21.11.jar"
+url = "https://cdn.modrinth.com/data/PtjYWJkn/versions/yqY1efrC/sodium-extra-fabric-0.8.3%2Bmc1.21.11.jar"
 hash-format = "sha512"
-hash = "03e1fe595ce5fe4d1cd2d15116d954e282910f606ba9fc5d8923b818b5018403a4ccef0ce1b0ebac2720f9882352cc984c393da2607de76c8b04b763356fb610"
+hash = "b268a22ec7d27a45142f839ecf9a902c4ead4a5ef01e480f9e042f700a75a12a0db6346914f5445be68136b849a068de88d54823444c5d13268cfc0661854465"
 
 [update]
 [update.modrinth]
 mod-id = "PtjYWJkn"
-version = "USJvTNro"
+version = "yqY1efrC"

--- a/versions/1.21.11/mods/sodium.pw.toml
+++ b/versions/1.21.11/mods/sodium.pw.toml
@@ -1,13 +1,13 @@
 name = "Sodium"
-filename = "sodium-fabric-0.8.2+mc1.21.11.jar"
+filename = "sodium-fabric-0.8.4+mc1.21.11.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/AANobbMI/versions/59wygFUQ/sodium-fabric-0.8.2%2Bmc1.21.11.jar"
+url = "https://cdn.modrinth.com/data/AANobbMI/versions/1OWNgWVR/sodium-fabric-0.8.4%2Bmc1.21.11.jar"
 hash-format = "sha512"
-hash = "0ab706031f954e4acfc0897536dcd182aaced35b912ee05f00a4c79609064c22d4249d7c1399b3359af974b258520664bbeb079d46f2e167f9f4d12ed86aeb37"
+hash = "c882e07f09ccc04b6258e79979a8e1429018de5b09da5fccea189d0a5de60ea5475f1884fc724f4d3ababc8abe730b9856d5e4864c3e418b21871dbaed21f0c3"
 
 [update]
 [update.modrinth]
 mod-id = "AANobbMI"
-version = "59wygFUQ"
+version = "1OWNgWVR"

--- a/versions/1.21.11/mods/yacl.pw.toml
+++ b/versions/1.21.11/mods/yacl.pw.toml
@@ -1,13 +1,13 @@
 name = "YetAnotherConfigLib"
-filename = "yet_another_config_lib_v3-3.8.1+1.21.11-fabric.jar"
+filename = "yet_another_config_lib_v3-3.8.2+1.21.11-fabric.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/1eAoo2KR/versions/NWFsMIGn/yet_another_config_lib_v3-3.8.1%2B1.21.11-fabric.jar"
+url = "https://cdn.modrinth.com/data/1eAoo2KR/versions/pHWDw3Vc/yet_another_config_lib_v3-3.8.2%2B1.21.11-fabric.jar"
 hash-format = "sha512"
-hash = "3a4f015644454dffd423272a8b066e6b94d0f982184ca8c492d996a4f30eb8247b1648fe936413e178d4da3c9266c00e9b864eb9a91f0815348ba5662596986c"
+hash = "392db7d471030cca27483ecf58c626a14cd73d71a18afe6d4173c6b030948b8a925b36e708d4cc2c897dfa3f20a7f23b999fc18aa6d36c156da29037601153ac"
 
 [update]
 [update.modrinth]
 mod-id = "1eAoo2KR"
-version = "NWFsMIGn"
+version = "pHWDw3Vc"

--- a/versions/1.21.11/mods/zoomify.pw.toml
+++ b/versions/1.21.11/mods/zoomify.pw.toml
@@ -1,13 +1,13 @@
 name = "Zoomify"
-filename = "Zoomify-2.14.6+1.21.11.jar"
+filename = "zoomify-2.15.2+1.21.11.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/w7ThoJFB/versions/6T6WQ6NZ/Zoomify-2.14.6%2B1.21.11.jar"
+url = "https://cdn.modrinth.com/data/w7ThoJFB/versions/gI5KZI8V/zoomify-2.15.2%2B1.21.11.jar"
 hash-format = "sha512"
-hash = "3a164fe4af7521ea8a6653d3e004e2d1ccc77c29afbf38b52a85a58eb6ddf6b1d2c6f896a0eeb08c32488819f4834b2d3818ebc61a5e8b40a4b09ffd779ff80f"
+hash = "de9d6097445175f6ef3e93475136fd67d29fc14fd26a6f19e63714efa6cf0961af5d270a95b65c4099a38517c3f91815fe4a1aa21b0acd84230398be2a6e3e24"
 
 [update]
 [update.modrinth]
 mod-id = "w7ThoJFB"
-version = "6T6WQ6NZ"
+version = "gI5KZI8V"

--- a/versions/1.21.11/pack.toml
+++ b/versions/1.21.11/pack.toml
@@ -6,10 +6,10 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "7b4da2b3d51ba66c3e1e96475453234857d5713e5487ea3c7a2e6e46cd396adb"
+hash = "cc9445534fbedb91e527991b3cfa70945c4c54b54988aa0c97389a63192c9995"
 
 [versions]
-fabric = "0.18.2"
+fabric = "0.18.4"
 minecraft = "1.21.11"
 
 [options]

--- a/versions/1.21.11/resourcepacks/translations-for-sodium.pw.toml
+++ b/versions/1.21.11/resourcepacks/translations-for-sodium.pw.toml
@@ -3,11 +3,11 @@ filename = "SodiumTranslations.zip"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/yfDziwn1/versions/gDwLP8mS/SodiumTranslations.zip"
+url = "https://cdn.modrinth.com/data/yfDziwn1/versions/FknJTNfY/SodiumTranslations.zip"
 hash-format = "sha512"
-hash = "b944342652363eb89d4c7570a76bad36bf068ccb958b0840dc789af293b9a6a1b491edd7f2df7df0bfe0bc1ac8931a00cd074192c3ad4788f2b530050d517f68"
+hash = "f738040e6030dcf8ff484620fbe59051fd75bf2684725043a296f423dd858353a1b6c522f367eb9d96c779d48bca473ecd60179165735082d093cce52e4ce8e2"
 
 [update]
 [update.modrinth]
 mod-id = "yfDziwn1"
-version = "gDwLP8mS"
+version = "FknJTNfY"

--- a/versions/1.21.11/shaderpacks/bsl-shaders.pw.toml
+++ b/versions/1.21.11/shaderpacks/bsl-shaders.pw.toml
@@ -1,13 +1,13 @@
 name = "BSL Shaders"
-filename = "BSL_v10.1p1.zip"
+filename = "BSL_v10.1.1.zip"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/Q1vvjJYV/versions/llOjTDPW/BSL_v10.1p1.zip"
+url = "https://cdn.modrinth.com/data/Q1vvjJYV/versions/NDEQ77pU/BSL_v10.1.1.zip"
 hash-format = "sha512"
-hash = "04ff6a2917e0fb6fd4febe839119e7029a9bf1252cfef98ff51e9fc695043b9d62b2e6dec26519031ed6e1e0d7dc1310cbbbb6ab9a27bb70dc1d85e2d103b8a6"
+hash = "defa91212ed082e3e25d349977cbeaf771ef6f8360e1bad8092c25ff73a967c8fcbb3673300cca6bcfb11732bad9d3a0ae023c111455a55ee28e55982d191cb9"
 
 [update]
 [update.modrinth]
 mod-id = "Q1vvjJYV"
-version = "llOjTDPW"
+version = "NDEQ77pU"

--- a/versions/1.21.11/shaderpacks/complementary-reimagined.pw.toml
+++ b/versions/1.21.11/shaderpacks/complementary-reimagined.pw.toml
@@ -1,13 +1,13 @@
 name = "Complementary Shaders - Reimagined"
-filename = "ComplementaryReimagined_r5.6.1.zip"
+filename = "ComplementaryReimagined_r5.7.1.zip"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/HVnmMxH1/versions/OfRF7dTR/ComplementaryReimagined_r5.6.1.zip"
+url = "https://cdn.modrinth.com/data/HVnmMxH1/versions/836bPNGo/ComplementaryReimagined_r5.7.1.zip"
 hash-format = "sha512"
-hash = "01426ce261df8a4fa99366efe30e98656bac43ac8a71db1265edb0b49c5e4abb9ada09d6877a6c1d728244fde202f57118339d3a0503a1cbc8af88325c8d4f5a"
+hash = "840149dd8aff5d5d06d0d5a4ea83d4ea7f72eab3cb2b02de513c1f3eaa6e4627f68d9c0915b86fa37edad73cafd4648f156f373da52810cd34c67d797e0f6aef"
 
 [update]
 [update.modrinth]
 mod-id = "HVnmMxH1"
-version = "OfRF7dTR"
+version = "836bPNGo"

--- a/versions/1.21.11/shaderpacks/complementary-unbound.pw.toml
+++ b/versions/1.21.11/shaderpacks/complementary-unbound.pw.toml
@@ -1,13 +1,13 @@
 name = "Complementary Shaders - Unbound"
-filename = "ComplementaryUnbound_r5.6.1.zip"
+filename = "ComplementaryUnbound_r5.7.1.zip"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/R6NEzAwj/versions/LXrX6oqm/ComplementaryUnbound_r5.6.1.zip"
+url = "https://cdn.modrinth.com/data/R6NEzAwj/versions/d8rcvDTp/ComplementaryUnbound_r5.7.1.zip"
 hash-format = "sha512"
-hash = "3c46b335faf0dde03666571d23bdc3aa04cdd30fa9ea3fd01214203a7a80bbf52ffa648b44d9c06c62308c234138da48a69ac381196de0683c57ec452ff68f41"
+hash = "207ad92ab354e1be002e1ccce978da3860af69532ddcdecbc2a943ffe1ff7ac5eec6b021073ae68b93d78499c63d505de3abf63d9058cdf6cb80bed6528b7532"
 
 [update]
 [update.modrinth]
 mod-id = "R6NEzAwj"
-version = "LXrX6oqm"
+version = "d8rcvDTp"

--- a/versions/1.21.11/shaderpacks/makeup-ultra-fast-shaders.pw.toml
+++ b/versions/1.21.11/shaderpacks/makeup-ultra-fast-shaders.pw.toml
@@ -1,13 +1,13 @@
 name = "MakeUp - Ultra Fast"
-filename = "MakeUp-UltraFast-9.3h.zip"
+filename = "MakeUp-UltraFast-9.4b.zip"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/izsIPI7a/versions/UH6jy81G/MakeUp-UltraFast-9.3h.zip"
+url = "https://cdn.modrinth.com/data/izsIPI7a/versions/CQSkSzPv/MakeUp-UltraFast-9.4b.zip"
 hash-format = "sha512"
-hash = "d1b40697e7cec5ddbd88cdc93374a9d6be70eecb9d3804f014ffa4b1238163813e1185cf9ff8fce9586cd192ffd56165ac141062ea6878c16cc8b9cfc34268b2"
+hash = "943a834e8dbfa2f7ac5059a5a7fadcc128052ca5d5103dd92494754cc4eeb677d975c45234effabac75742d2d9c567a33bd9b6a3c0ddfbb1004f2bb729e32ef3"
 
 [update]
 [update.modrinth]
 mod-id = "izsIPI7a"
-version = "UH6jy81G"
+version = "CQSkSzPv"

--- a/versions/1.21.11/shaderpacks/mellow.pw.toml
+++ b/versions/1.21.11/shaderpacks/mellow.pw.toml
@@ -1,13 +1,13 @@
 name = "Mellow"
-filename = "Mellow v2.2.1.zip"
+filename = "Mellow Shader v3.0.1.zip"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/BUxf36AP/versions/qlkWjU3S/Mellow%20v2.2.1.zip"
+url = "https://cdn.modrinth.com/data/BUxf36AP/versions/UZr9vbx6/Mellow%20Shader%20v3.0.1.zip"
 hash-format = "sha512"
-hash = "046daf1b44e3a8da0de1f25c173f70cf31c167204744a9c9ed6a30b8052795c477b21998396ed2d0233615e79a00f3d2e19ede88fd65dcfaf3b335873cadde9a"
+hash = "caa144a426e974910ebd0e561fae03d74b999a9d646f6cf2e422f4c1bdc2c2cff73c56bf8ca8c99b1fabc7b6568a110d8cd4f4de8e001338444d692ba60324c3"
 
 [update]
 [update.modrinth]
 mod-id = "BUxf36AP"
-version = "qlkWjU3S"
+version = "UZr9vbx6"

--- a/versions/1.21.11/shaderpacks/miniature-shader.pw.toml
+++ b/versions/1.21.11/shaderpacks/miniature-shader.pw.toml
@@ -1,13 +1,13 @@
 name = "Miniature Shader"
-filename = "miniature-shader-2.18.6.zip"
+filename = "miniature-shader-2.18.9.zip"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/UaS8ROxa/versions/NIqFXspW/miniature-shader-2.18.6.zip"
+url = "https://cdn.modrinth.com/data/UaS8ROxa/versions/tyB7b4ka/miniature-shader-2.18.9.zip"
 hash-format = "sha512"
-hash = "983758894fe05f472d55f522e3fbbf4399f06506837e43437237cdc6439f2ea6665fd35194ce21954335118c81a1a175359e5cecf60939daa1cc3bfdbae81434"
+hash = "2bbf197a25efbabd127d17a4a5c5c189d7d503ab4a267027f71388fcfeef96724254ad0f8d8a45742ba2c6fe079012b3a1fd84153a2a00a167936502ce8d3b42"
 
 [update]
 [update.modrinth]
 mod-id = "UaS8ROxa"
-version = "NIqFXspW"
+version = "tyB7b4ka"

--- a/versions/1.21.11/shaderpacks/super-duper-vanilla.pw.toml
+++ b/versions/1.21.11/shaderpacks/super-duper-vanilla.pw.toml
@@ -1,0 +1,14 @@
+name = "Super Duper Vanilla"
+filename = "superDuperVanilla.zip"
+side = "client"
+pin = true
+
+[download]
+url = "https://cdn.modrinth.com/data/LMIZZNxZ/versions/KB0sOLSc/superDuperVanilla.zip"
+hash-format = "sha512"
+hash = "231b47716d5dab68fd1409c65750589c234d4d63312b3f8634342477686ae6db88edb9ecc3c5662fca245e71b16f16e2933e50751d13d5b06e7d3e26f8d9ebaf"
+
+[update]
+[update.modrinth]
+mod-id = "LMIZZNxZ"
+version = "KB0sOLSc"


### PR DESCRIPTION
Notable changes to this update for Minecraft 1.21.1! (Mounts of Mayhem)

Minecraft Version

• Version 1.21.11

Fabric Support

• Loader version 0.18.4

### Package Updates

Mods:

• Updated: Entity Culling
• Updated: Entity Texture Features
• Updated: Fabric API
• Updated: Fabric Language Kotlin
• Updated: Ferrite Core
• Updated: Immediately Fast
• Updated: Iris Shaders
• Updated: Lithium
• Updated: Mod Menu
• Updated: More Culling
• Updated: Reeses Sodium Options
• Updated: Shulker Box Tooltip
• Updated: Simple Voice Chat
• Updated: Sodium Extras
• Updated: Sodium
• Updated: Yet Another Config Library
• Updated: Zoomify

Shaderpack Changes

• Updated: BSL Shaders
• Updated: Complementary Reimagined
• Updated: Complementary Unbound
• Updated: Makeup - Ultra Fast
• Updated: Mellow Shader
• Updated: Miniature Shader
• Added: Super Duper Vanilla

Resource Pack Changes

• Updated: Sodium Translations
