### PR TITLE
feat/ MC 26.1.2 patch for retiNO support

### DIFF
--- a/versions/26.1/index.toml
+++ b/versions/26.1/index.toml
@@ -1,6 +1,10 @@
 hash-format = "sha256"
 
 [[files]]
+file = ".antigravitycli/b80245be-69b1-4c02-8b46-53994603cab8.json"
+hash = "71f4fb171ba065755cb69f58ec79bf4351f6d9355d19326ba4dd8c6a93e6d3ab"
+
+[[files]]
 file = "LICENSE"
 hash = "2697e02e79ba657a756f819351d5f154d134c149d9669bdb056e57cd523785e6"
 
@@ -65,7 +69,7 @@ metafile = true
 
 [[files]]
 file = "mods/fabric-api.pw.toml"
-hash = "dae57c5a1bea0fb7b104fff48e4dd5b76c0eb46cb198f65b4a3ca13316c86d20"
+hash = "2a77dc7aade5de6d21315582c4b70db40ff2bdf746b61c10d7ad3c5be8422f75"
 metafile = true
 
 [[files]]
@@ -125,7 +129,7 @@ metafile = true
 
 [[files]]
 file = "mods/retino.pw.toml"
-hash = "512c2bd9b6cd2a1e25c362734d5b7cdb98663daed6efd0075bff9d523471b70b"
+hash = "b823d521368428e4e13ae2a763201c04300fbbf8c06d7380b3ee3425a837bf6c"
 metafile = true
 
 [[files]]
@@ -150,7 +154,7 @@ metafile = true
 
 [[files]]
 file = "mods/sodium.pw.toml"
-hash = "61e81490e34e2fad9b8fda7419fd6ef72f3aad942ab210a70142af0bd806f409"
+hash = "e5278cc1dcda4fe789eaf05318fa5885f9f3412685f8ac231fe9a395409089e0"
 metafile = true
 
 [[files]]
@@ -174,7 +178,7 @@ metafile = true
 
 [[files]]
 file = "resourcepacks/translations-for-sodium.pw.toml"
-hash = "9ebd5ffa0b9740b9b19ba85076976a3850f4e3996fb19efd34e0a15141dbd4a9"
+hash = "039796b7190abfcdd7ee0f591fa314033e9cc8308bad85e1ca59ce148e68ada5"
 metafile = true
 
 [[files]]
@@ -196,22 +200,22 @@ metafile = true
 
 [[files]]
 file = "shaderpacks/complementary-reimagined.pw.toml"
-hash = "844af68c07eac70b45bb488a7d9af2298cd6f2867d1ad33fd7abe94110dfedb1"
+hash = "ea258ed5bf495d9017eeadc3cbf9bd67b1e672d843826bc077135548b5bc699e"
 metafile = true
 
 [[files]]
 file = "shaderpacks/complementary-unbound.pw.toml"
-hash = "4186d52e3f4eadf4ba35098431dd9d209d3f2637b1c7abb5668894594cc88246"
+hash = "608b87f75b2387a9fbd340cb18a8238bbbe5a0afc54202634b34f3000246b6e7"
 metafile = true
 
 [[files]]
 file = "shaderpacks/makeup-ultra-fast-shaders.pw.toml"
-hash = "85edba5e221fc8c2cbf4fbdd4b6b1973fcfb3aa571cbe68f0d4df5d8aa5c9750"
+hash = "76c678ce2d09d603d0f80d7d9210c7da006878a14f6855d228a6021acdf0687d"
 metafile = true
 
 [[files]]
 file = "shaderpacks/mellow.pw.toml"
-hash = "8fa5ab69b76136f30b45a5946f109dc80716ec58be151d0a838e47912e902cf7"
+hash = "fae99faa6d15195bf1bcffc8ab62e24eb50b93495694b7b58d8181a9f0706c1b"
 metafile = true
 
 [[files]]

--- a/versions/26.1/mods/fabric-api.pw.toml
+++ b/versions/26.1/mods/fabric-api.pw.toml
@@ -1,13 +1,13 @@
 name = "Fabric API"
-filename = "fabric-api-0.149.0+26.1.2.jar"
+filename = "fabric-api-0.149.1+26.1.2.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/P7dR8mSH/versions/Sy2Bq7Xc/fabric-api-0.149.0%2B26.1.2.jar"
+url = "https://cdn.modrinth.com/data/P7dR8mSH/versions/BLz7ETCw/fabric-api-0.149.1%2B26.1.2.jar"
 hash-format = "sha512"
-hash = "c7589aa4deeaa6dbefc13247eb5e0d4e257c152ef039937f54d6ee28282d3c84ccc96483d9c3950286fed6e3dcc546709898c8a446ab143d1663bc7d49649c54"
+hash = "47ffa18369260c88ea847f6694ccb431a5aa9051c64e8d361186a767bb762dd9fcfbf4742ac65505eb60862900a1a3f1490994e7435376607de811eab8be4461"
 
 [update]
 [update.modrinth]
 mod-id = "P7dR8mSH"
-version = "Sy2Bq7Xc"
+version = "BLz7ETCw"

--- a/versions/26.1/mods/retino.pw.toml
+++ b/versions/26.1/mods/retino.pw.toml
@@ -1,14 +1,13 @@
 name = "retiNO"
-filename = "retino-1.0.1.jar"
+filename = "retiNO-ver-26.1-1.1.0.jar"
 side = "both"
-pin = true
 
 [download]
-url = "https://cdn.modrinth.com/data/z7dmZ4nL/versions/1.0.1/retino-1.0.1.jar"
-hash-format = "sha1"
-hash = "8f5412e647d345cff1bb7d85a645d50768ca294b"
+url = "https://cdn.modrinth.com/data/z7dmZ4nL/versions/WXp30SQo/retiNO-ver-26.1-1.1.0.jar"
+hash-format = "sha512"
+hash = "b03fafd8e1e725dc62be54b52e800bd23127831230ec541b8bdb991a634a554ba7c7695fa113d7c5fae5982e7854a4d2b573a1afc8298ab4e873192e89d230f6"
 
 [update]
 [update.modrinth]
 mod-id = "z7dmZ4nL"
-version = "gyLsjEk8"
+version = "WXp30SQo"

--- a/versions/26.1/mods/sodium.pw.toml
+++ b/versions/26.1/mods/sodium.pw.toml
@@ -1,13 +1,13 @@
 name = "Sodium"
-filename = "sodium-fabric-0.8.12-beta.4+mc26.1.2.jar"
+filename = "sodium-fabric-0.8.12+mc26.1.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/AANobbMI/versions/8l4Yx5Q1/sodium-fabric-0.8.12-beta.4%2Bmc26.1.2.jar"
+url = "https://cdn.modrinth.com/data/AANobbMI/versions/eRJU33Hp/sodium-fabric-0.8.12%2Bmc26.1.2.jar"
 hash-format = "sha512"
-hash = "11782aa9f062f08386cd3cfc1a442715f84382dfd6f7b04095071970c785a8913b004a46dbe490ef30e80ca5bba45c7615c839c04fa866924b4c325f6d260641"
+hash = "402bb945d1f893a72c152c137e08f8a0c045d725a4d6ca2af7bcfe929c4d80338da509094cfe3a8cd162346b78c5069dc3cf1d57bf94a1bce557f6425da7e76f"
 
 [update]
 [update.modrinth]
 mod-id = "AANobbMI"
-version = "8l4Yx5Q1"
+version = "eRJU33Hp"

--- a/versions/26.1/pack.toml
+++ b/versions/26.1/pack.toml
@@ -1,12 +1,12 @@
 name = "Mac OS Optimized"
 author = "scriptmunkee"
-version = "1.2.0"
+version = "1.2.1"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "2e5dacd23c43668fee8caf380782b2cbae948d977fde4f7741c3f013bcefcccc"
+hash = "98e9fbfb26fa381516f256ba8733215eef985cc4dec1eaa695e5b9741f3cd398"
 
 [versions]
 fabric = "0.149.0+26.1.2"

--- a/versions/26.1/resourcepacks/translations-for-sodium.pw.toml
+++ b/versions/26.1/resourcepacks/translations-for-sodium.pw.toml
@@ -3,11 +3,11 @@ filename = "SodiumTranslations.zip"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/yfDziwn1/versions/oH4e56Ma/SodiumTranslations.zip"
+url = "https://cdn.modrinth.com/data/yfDziwn1/versions/FssqfKaV/SodiumTranslations.zip"
 hash-format = "sha512"
-hash = "bf716bf17fb10d801d419bc7ca383b39753a422d2dd3da5abc55bf1fcd02f1d82f08e0fa800b32440f622ca69a172cacca31f2fb2d312fe7e31344564627ea14"
+hash = "dbf73f963ff734a5510d989a06b2af07df6951de74f23addbdf2c0924d3a968259ec746b4c4c26d5ed0a62ebb49ca46fd352191cb2f9f78a9bc3704e6d58c022"
 
 [update]
 [update.modrinth]
 mod-id = "yfDziwn1"
-version = "oH4e56Ma"
+version = "FssqfKaV"

--- a/versions/26.1/shaderpacks/complementary-reimagined.pw.toml
+++ b/versions/26.1/shaderpacks/complementary-reimagined.pw.toml
@@ -1,13 +1,13 @@
 name = "Complementary Shaders - Reimagined"
-filename = "ComplementaryReimagined_r5.8.zip"
+filename = "ComplementaryReimagined_r5.8.1.zip"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/HVnmMxH1/versions/7RRmkxkn/ComplementaryReimagined_r5.8.zip"
+url = "https://cdn.modrinth.com/data/HVnmMxH1/versions/yCCduG44/ComplementaryReimagined_r5.8.1.zip"
 hash-format = "sha512"
-hash = "8def9f83ba0015c3d7eadcec1fdb1ecb8ac999496f35d15468bae753c79b26168567e1375218a54fe0c50d97d140555ef26f79dbfcb8b4d526a7d8f3483407bc"
+hash = "6bd95215755d25812556ce790d976221f7d677d63112e3e4d3e70b08a62ed41348fa3792dd31bbe720d1e46fe2d525cadb4f66e6358118e1f4aa8e0d11f25c39"
 
 [update]
 [update.modrinth]
 mod-id = "HVnmMxH1"
-version = "7RRmkxkn"
+version = "yCCduG44"

--- a/versions/26.1/shaderpacks/complementary-unbound.pw.toml
+++ b/versions/26.1/shaderpacks/complementary-unbound.pw.toml
@@ -1,13 +1,13 @@
 name = "Complementary Shaders - Unbound"
-filename = "ComplementaryUnbound_r5.8.zip"
+filename = "ComplementaryUnbound_r5.8.1.zip"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/R6NEzAwj/versions/BTHXcCkt/ComplementaryUnbound_r5.8.zip"
+url = "https://cdn.modrinth.com/data/R6NEzAwj/versions/VMHXIk50/ComplementaryUnbound_r5.8.1.zip"
 hash-format = "sha512"
-hash = "597d36e03473c38f52bbdbbf602961abcf740a53b4d7004178b7aa54abc0d171c83ee31d6e94b93befefb2de39245a85e40f7def6e4e3e5010eb759a152625c0"
+hash = "9098dd9e0c18b80f7aba2839cea33ce9a614d97665bbfcac87ccce6e4771667c41602d99088852cb1642ccab20b2ceff9b98af8f2e795bd0d3b90b7c9cbab914"
 
 [update]
 [update.modrinth]
 mod-id = "R6NEzAwj"
-version = "BTHXcCkt"
+version = "VMHXIk50"

--- a/versions/26.1/shaderpacks/makeup-ultra-fast-shaders.pw.toml
+++ b/versions/26.1/shaderpacks/makeup-ultra-fast-shaders.pw.toml
@@ -1,13 +1,13 @@
 name = "MakeUp - Ultra Fast"
-filename = "MakeUp-UltraFast-9.5a.zip"
+filename = "MakeUp-UltraFast-9.5b.zip"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/izsIPI7a/versions/XBjEbZ1I/MakeUp-UltraFast-9.5a.zip"
+url = "https://cdn.modrinth.com/data/izsIPI7a/versions/V5pgSLtI/MakeUp-UltraFast-9.5b.zip"
 hash-format = "sha512"
-hash = "ec8a7409da5b404055b9fe322dcd22f7297e51a917e4e4cb64422a6fbdab232e415b04589f206b10a023dfb39cc752fd4dd80321ca7efc3fe2a063a37b79c867"
+hash = "c4052ae04dda5c11bfbc77146c45cc09556f32cb89e5bfd19f31dc5fa78b644fc32ef978ee476b728cc4e3ba10bb7cbb9e7e799329a506c2ad8e720c10f43018"
 
 [update]
 [update.modrinth]
 mod-id = "izsIPI7a"
-version = "XBjEbZ1I"
+version = "V5pgSLtI"

--- a/versions/26.1/shaderpacks/mellow.pw.toml
+++ b/versions/26.1/shaderpacks/mellow.pw.toml
@@ -1,13 +1,13 @@
 name = "Mellow"
-filename = "Mellow Shader v3.1.1.zip"
+filename = "Mellow Shader v3.2.zip"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/BUxf36AP/versions/VghwS71C/Mellow%20Shader%20v3.1.1.zip"
+url = "https://cdn.modrinth.com/data/BUxf36AP/versions/jSMKKxo3/Mellow%20Shader%20v3.2.zip"
 hash-format = "sha512"
-hash = "bbf3afea4dd30e1d25027e48f1c8434034617553d6886dd463de03c9c8a013c878061b63890846a19287177d3590a86471f9030f6d4025578392ce1ec31c8bfd"
+hash = "1e431b67cbcacc07a589d68ff29eb8e85a968e25d829fa708bd7e50683258ed1df8f43fba23929518d79820bded22d8667557f410a16ae2f8b3cc1c6169eb90e"
 
 [update]
 [update.modrinth]
 mod-id = "BUxf36AP"
-version = "VghwS71C"
+version = "jSMKKxo3"


### PR DESCRIPTION
## Changelog

Patch 1.2.1 for Minecraft 26.1.2

Major change is an update to retiNO which improves FPS

**Minecraft Version**
   - Version 26.1.2

**Fabric Support**
   - Loader version 0.149.0+26.1.2

-----------------------

**Package Updates**

**Mods:**

   - Updated fabric-api.pw.toml
   - Updated retino.pw.toml
   - Updated sodium.pw.toml

**Shaderpack Changes:**

   - Updated: shaderpacks/complementary-reimagined.pw.toml
   - Updated: shaderpacks/complementary-unbound.pw.toml
   - Updated: shaderpacks/makeup-ultra-fast-shaders.pw.toml
   - Updated: shaderpacks/mellow.pw.toml

**Resource Pack Changes:**
   - Updated: translations-for-sodium.pw.toml